### PR TITLE
Require ruby-duration 3.2.3+ to avoid issues:

### DIFF
--- a/interactive-logger.gemspec
+++ b/interactive-logger.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/askreet/interactive-logger'
 
   s.add_dependency('colorize', '~> 0.7.7')
-  s.add_dependency('ruby-duration', '~> 3.2', '>= 3.2.1')
+  s.add_dependency('ruby-duration', '~> 3.2', '>= 3.2.3')
 end


### PR DESCRIPTION
- < 3.2.2 includes in activesupport json which breaks time formatting in JSON objects.
- 3.2.2 doesn't load default activesupport translations, often causing I18n exception.
